### PR TITLE
Use integer division to feed range function

### DIFF
--- a/satumut/analysis.py
+++ b/satumut/analysis.py
@@ -824,7 +824,7 @@ def complete_analysis(folders, wild, base, dpi=800, traj=10, output="summary", p
     atoms: list[str]
         Series of atoms of the residues to follow in this format -> chain ID:position:atom name, multiple of 2
     """
-    col = ["distance{}.5".format(x) for x in range(len(atoms)/2)]
+    col = ["distance{}.5".format(x) for x in range(len(atoms)//2)]
     for follow in col:
         data_dict = analyse_all(folders, wild, traj, cata_dist, energy_thres, follow=follow)
         bins = binning(data_dict, plot_dir, base, dpi=800, follow=follow)


### PR DESCRIPTION
Python 3 by default uses float division, when passing a value to the range function, which requires an int, using the integer division operator (//) avoids problems and is python 2/3 compatible